### PR TITLE
Center window on current screen

### DIFF
--- a/addons/ggs/classes/ggs_utils.gd
+++ b/addons/ggs/classes/ggs_utils.gd
@@ -65,10 +65,10 @@ static func window_clamp_to_screen(size: Vector2) -> Vector2:
 
 
 static func center_window() -> void:
-	var screen = DisplayServer.window_get_current_screen()
-	var display_size: Vector2 = DisplayServer.screen_get_size(screen)
-	var window_size: Vector2 = DisplayServer.window_get_size(screen)
-	var origin = Vector2(DisplayServer.screen_get_position(screen))
+	var screen_id: int = DisplayServer.window_get_current_screen()
+	var display_size: Vector2i = DisplayServer.screen_get_size(screen_id)
+	var window_size: Vector2i = DisplayServer.window_get_size()
+	var origin: Vector2i = DisplayServer.screen_get_position(screen_id)
 	var target_pos: Vector2 = origin + (display_size / 2) - (window_size / 2)
 	DisplayServer.window_set_position(target_pos)
 

--- a/addons/ggs/classes/ggs_utils.gd
+++ b/addons/ggs/classes/ggs_utils.gd
@@ -67,7 +67,7 @@ static func window_clamp_to_screen(size: Vector2) -> Vector2:
 static func center_window() -> void:
 	var screen = DisplayServer.window_get_current_screen()
 	var display_size: Vector2 = DisplayServer.screen_get_size(screen)
-	var window_size: Vector2 = DisplayServer.window_get_size()
+	var window_size: Vector2 = DisplayServer.window_get_size(screen)
 	var origin = Vector2(DisplayServer.screen_get_position(screen))
 	var target_pos: Vector2 = origin + (display_size / 2) - (window_size / 2)
 	DisplayServer.window_set_position(target_pos)

--- a/addons/ggs/classes/ggs_utils.gd
+++ b/addons/ggs/classes/ggs_utils.gd
@@ -65,9 +65,11 @@ static func window_clamp_to_screen(size: Vector2) -> Vector2:
 
 
 static func center_window() -> void:
-	var display_size: Vector2 = DisplayServer.screen_get_size()
+	var screen = DisplayServer.window_get_current_screen()
+	var display_size: Vector2 = DisplayServer.screen_get_size(screen)
 	var window_size: Vector2 = DisplayServer.window_get_size()
-	var target_pos: Vector2 = (display_size / 2) - (window_size / 2)
+	var origin = Vector2(DisplayServer.screen_get_position(screen))
+	var target_pos: Vector2 = origin + (display_size / 2) - (window_size / 2)
 	DisplayServer.window_set_position(target_pos)
 
 


### PR DESCRIPTION
Changing the window size moves the window to the left monitor on multi-monitor setups.
This change keeps the window on the current monitor after centering.