### PR TITLE
Add error prevention for mouses with 5+ buttons

### DIFF
--- a/addons/ggs/classes/ggs_input_helper.gd
+++ b/addons/ggs/classes/ggs_input_helper.gd
@@ -189,12 +189,6 @@ func _get_kb_event_string(event: InputEventKey) -> String:
 
 func _get_mouse_event_as_text(event: InputEventMouseButton) -> String:
 	var modifiers: String = _get_modifiers_string(event, true)
-	
-	var btn_index: int = event.button_index - 1
-	
-	if not _button_index_is_valid(event.button_index):
-		return "Unknown Mouse Button"
-	
 	var btn: String = keywords["mouse"][event.button_index - 1].to_upper()
 	var result: String = "%s"%btn if modifiers.is_empty() else "%s+%s"%[modifiers, btn]
 	return result
@@ -210,10 +204,6 @@ func _create_mouse_event(modifiers: PackedStringArray, btn: String) -> InputEven
 
 func _get_mouse_event_string(event: InputEventMouseButton) -> String:
 	var modifiers: String = _get_modifiers_string(event)
-	
-	if not _button_index_is_valid(event.button_index):
-		return "unknown_mb"
-	
 	var btn: String = keywords["mouse"][event.button_index - 1]
 	var result: String = "%s"%btn if modifiers.is_empty() else "%s,%s"%[modifiers, btn]
 	
@@ -223,9 +213,6 @@ func _get_mouse_event_string(event: InputEventMouseButton) -> String:
 func _string_is_for_mouse(btn: String) -> bool:
 	return keywords["mouse"].has(btn)
 
-
-func _button_index_is_valid(btn_index: int) -> bool:
-	return btn_index >= 0 and btn_index <= 9
 
 
 ### Gamepad

--- a/addons/ggs/classes/ggs_input_helper.gd
+++ b/addons/ggs/classes/ggs_input_helper.gd
@@ -189,6 +189,12 @@ func _get_kb_event_string(event: InputEventKey) -> String:
 
 func _get_mouse_event_as_text(event: InputEventMouseButton) -> String:
 	var modifiers: String = _get_modifiers_string(event, true)
+	
+	var btn_index: int = event.button_index - 1
+	
+	if not _button_index_is_valid(event.button_index):
+		return "Unknown Mouse Button"
+	
 	var btn: String = keywords["mouse"][event.button_index - 1].to_upper()
 	var result: String = "%s"%btn if modifiers.is_empty() else "%s+%s"%[modifiers, btn]
 	return result
@@ -204,6 +210,10 @@ func _create_mouse_event(modifiers: PackedStringArray, btn: String) -> InputEven
 
 func _get_mouse_event_string(event: InputEventMouseButton) -> String:
 	var modifiers: String = _get_modifiers_string(event)
+	
+	if not _button_index_is_valid(event.button_index):
+		return "unknown_mb"
+	
 	var btn: String = keywords["mouse"][event.button_index - 1]
 	var result: String = "%s"%btn if modifiers.is_empty() else "%s,%s"%[modifiers, btn]
 	
@@ -212,6 +222,10 @@ func _get_mouse_event_string(event: InputEventMouseButton) -> String:
 
 func _string_is_for_mouse(btn: String) -> bool:
 	return keywords["mouse"].has(btn)
+
+
+func _button_index_is_valid(btn_index: int) -> bool:
+	return btn_index >= 0 and btn_index <= 9
 
 
 ### Gamepad

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -1,0 +1,65 @@
+[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+dedicated_server=false
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path=""
+encryption_include_filters=""
+encryption_exclude_filters=""
+encrypt_pck=false
+encrypt_directory=false
+script_encryption_key=""
+
+[preset.0.options]
+
+custom_template/debug=""
+custom_template/release=""
+debug/export_console_script=1
+binary_format/embed_pck=false
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+binary_format/architecture="x86_64"
+codesign/enable=false
+codesign/identity_type=0
+codesign/identity=""
+codesign/password=""
+codesign/timestamp=true
+codesign/timestamp_server_url=""
+codesign/digest_algorithm=1
+codesign/description=""
+codesign/custom_options=PackedStringArray()
+application/modify_resources=true
+application/icon=""
+application/console_wrapper_icon=""
+application/icon_interpolation=4
+application/file_version=""
+application/product_version=""
+application/company_name=""
+application/product_name=""
+application/file_description=""
+application/copyright=""
+application/trademarks=""
+ssh_remote_deploy/enabled=false
+ssh_remote_deploy/host="user@host_ip"
+ssh_remote_deploy/port="22"
+ssh_remote_deploy/extra_args_ssh=""
+ssh_remote_deploy/extra_args_scp=""
+ssh_remote_deploy/run_script="Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'
+$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'
+$trigger = New-ScheduledTaskTrigger -Once -At 00:00
+$settings = New-ScheduledTaskSettingsSet
+$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings
+Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true
+Start-ScheduledTask -TaskName godot_remote_debug
+while (Get-ScheduledTask -TaskName godot_remote_debug | ? State -eq running) { Start-Sleep -Milliseconds 100 }
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue"
+ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
+Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
+Remove-Item -Recurse -Force '{temp_dir}'"

--- a/game_settings/components/_misc_components/input_confirm_window/input_confirm_window.gd
+++ b/game_settings/components/_misc_components/input_confirm_window/input_confirm_window.gd
@@ -96,8 +96,10 @@ func _event_is_valid(event: InputEvent) -> bool:
 		has_modifier = (event.shift_pressed or event.alt_pressed or event.ctrl_pressed)
 	
 	var is_double_click: bool = false
+	var mouse_button_is_valid: bool = true
 	if event is InputEventMouseButton:
 		is_double_click = event.double_click
+		mouse_button_is_valid = (event.button_index >= 0 and event.button_index <= 9)
 	
 	var is_valid: bool
 	if accept_modifiers:
@@ -105,13 +107,15 @@ func _event_is_valid(event: InputEvent) -> bool:
 		type_is_valid and
 		event.is_pressed() and
 		not event.is_echo() and
-		not is_double_click)
+		not is_double_click and
+		mouse_button_is_valid)
 	else:
 		is_valid = (
 		type_is_valid and
 		event.is_pressed() and
 		not event.is_echo() and
-		not is_double_click and 
+		not is_double_click and
+		mouse_button_is_valid and 
 		not has_modifier)
 	
 	return is_valid


### PR DESCRIPTION
Potentially resolves #29.
I personally don't have a mouse with more than 5 buttons so this needs to be validated by someone else.
While this doesn't add input binding support for the 6th, 7th, 8th, etc. mouse buttons, it should at least prevent the game from crashing when a player decides to bind an action to those extra mouse buttons by not accepting their input events.