### PR TITLE
Fix category change in editor in 4.1

### DIFF
--- a/addons/ggs/classes/ggs_globals.gd
+++ b/addons/ggs/classes/ggs_globals.gd
@@ -4,6 +4,7 @@ extends Node
 ### Signals
 
 signal category_selected(category: ggsCategory)
+signal category_changed(category: ggsCategory)
 signal setting_selected(setting: ggsSetting)
 
 
@@ -79,6 +80,7 @@ func _ready() -> void:
 
 func _on_category_selected(category: ggsCategory) -> void:
 	active_category = category
+	category_changed.emit(category)
 
 
 func _on_setting_selected(setting: ggsSetting) -> void:

--- a/addons/ggs/editor/setting_panel/setting_list.gd
+++ b/addons/ggs/editor/setting_panel/setting_list.gd
@@ -5,7 +5,7 @@ extends ggsTree
 func _ready() -> void:
 	item_selected.connect(_on_item_selected)
 	item_activated.connect(_on_item_activated)
-	GGS.category_selected.connect(_on_Global_category_selected)
+	GGS.category_changed.connect(_on_Global_category_selected)
 
 
 func add_item(setting: ggsSetting) -> void:


### PR DESCRIPTION
I looked into [issue 35](https://github.com/PunchablePlushie/godot-game-settings/issues/35) a bit since it affected me too. Both the code that changes active_category and the one that updates the list are connected to the same signal. In the engine there is no guarantee to the order of the callback functions of signals (afaik).

I guess something changed in godot that caused a change in behaviour. It can't really be called a bug on the engine's part because they never said the signal call order is reliable.

Since in this case there is a requirement to call these functions is a predetermined order a new signal is added. It is called after changing the active category. This way the functions are always called in the right order.
I tested it and it works without any issues but I have not tested in 4.0. I have no reason to suspect it wont work.

There are other ways to fix this, but this one is nice, it preserves the architecture.