### PR TITLE
Add 'axis_value' to 'event_id' for JoypadMotion input events

### DIFF
--- a/classes/ggs_input_helper.gd
+++ b/classes/ggs_input_helper.gd
@@ -65,7 +65,8 @@ func get_event_id(event: InputEvent) -> int:
 		return event.button_index
 	
 	if event is InputEventJoypadMotion:
-		return event.axis
+		# Pack values to int
+		return (10 * event.axis) + roundi(event.axis_value) + 5
 	
 	return -1
 
@@ -83,7 +84,9 @@ func set_event_id(event: InputEvent, id: int) -> void:
 		event.button_index = id
 	
 	if event is InputEventJoypadMotion:
-		event.axis = id
+		# Unpack values from int
+		event.axis = roundi((id - 5) / 10.0)
+		event.axis_value = (id % 10) - 5
 
 
 func get_event_type(event: InputEvent) -> InputType:


### PR DESCRIPTION
This is a small fix for an issue I faced with joystick motion actions not retaining what direction they should be bound to. This example fix packs both the `axis` and `axis_value` into the `event_id` serialization + deserialization functions.

Example showing impact of change with included input setting + UI:

Before:
<img width="688" alt="Screenshot showing both up and down actions being bound to 'LStick Down' and left and right actions being bound to 'LStick Right'" src="https://github.com/PunchablePlushie/godot-game-settings/assets/91758145/27e141e9-bf3a-46db-869c-0da6533701c6">

After:
<img width="688" alt="Screenshot showing all actions being bound to individual axis + direction combinations" src="https://github.com/PunchablePlushie/godot-game-settings/assets/91758145/890147ca-ed56-433d-a3c3-efc85c88c6c6">

