### PR TITLE
Fix fullscreen setting not setting to windowed

### DIFF
--- a/addons/ggs/templates/display/setting_display_fullscreen.gd
+++ b/addons/ggs/templates/display/setting_display_fullscreen.gd
@@ -19,9 +19,9 @@ func apply(value: bool) -> void:
 	var window_mode: DisplayServer.WindowMode
 	match value:
 		true:
-			window_mode = DisplayServer.WINDOW_MODE_FULLSCREEN
-		false:
 			window_mode = DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN
+		false:
+			window_mode = DisplayServer.MODE_WINDOWED
 
 	DisplayServer.window_set_mode(window_mode)
 


### PR DESCRIPTION
Fix of #58 included an error where, instead of replacing ``MODE_FULLSCREEN`` with ``MODE_EXCLUSIVE_FULLSCREEN``, ``MODE_WINDOWED`` was replaced instead. This pull fixes that.