### PR TITLE
fix applying wrong value(value before reset) on reset

### DIFF
--- a/addons/ggs/core/component.gd
+++ b/addons/ggs/core/component.gd
@@ -96,7 +96,8 @@ func apply_setting() -> void:
 ## Saves the default value of the setting to the save file and applies it to the game, effectively reseting it.[br]
 ## A ResetBtn calls this method to reset its associated settings.
 func reset_setting() -> void:
-	GGSSaveManager.save_setting_value(setting, setting.default)
+	value = setting.default
+	GGSSaveManager.save_setting_value(setting, value)
 	GGS.setting_applied.emit(setting, value)
 	setting.apply(value)
 


### PR DESCRIPTION
## Motivation
Some components’ reset behavior relied on `Component.value` instead of `setting.default`.  
This caused inconsistencies when resetting settings.

## Changes
- Updated `Component.reset_setting`:
  - First assign `value`
  - Then perform **save** and **apply** operations

## Impact
- Ensures reset uses the intended `setting.default`
- Provides consistent reset behavior across components

## Suggestion
For components inheriting from `Component`,  
`apply_setting()` should **not** be called again when using `super()`.  
This prevents redundant operations and keeps the reset logic consistent.
