### PR TITLE
Fix docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Godot Game Settings allows you to create and manage game settings for small to medium sized projects. It includes predefined logic for common game settings (display, audio, input) in addition to a framework for creating and managing custom settings and user interface components.
 
-View the [documentation](https://punchableplushie.github.io/godot-game-settings-docs) for information on how to use the plugin.
+View the [documentation](https://c16s8.github.io/godot-game-settings-docs) for information on how to use the plugin.
 
 <p align="center">
 	<img src="https://i.postimg.cc/cCGPB9Kt/ggs-icon.png" alt="GGS icon">


### PR DESCRIPTION
The current link to documentation is trying to access a page that belongs to punchableplushie which doesn't exist.
I simply changed the user to c16s8 and it worked like a charm.