### PR TITLE
Fix doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Godot Game Settings allows you to create and manage game settings for small to medium sized projects. It includes predefined logic for common game settings (display, audio, input) in addition to a framework for creating and managing custom settings and user interface components.
 
-View the [documentation](https://punchableplushie.github.io/godot-game-settings-docs) for information on how to use the plugin.
+View the [documentation](https://zijcht.github.io/godot-game-settings-docs/) for information on how to use the plugin.
 
 <p align="center">
 	<img src="https://i.postimg.cc/cCGPB9Kt/ggs-icon.png" alt="GGS icon">


### PR DESCRIPTION
There's an older pull request at https://github.com/zijcht/godot-game-settings/pull/68, which already seems to be outdated because the user has again changed their username.

Because of that, I have again updated the link to be consistent with the owner's username at README.md.